### PR TITLE
fix hardcoded typecast to (int) for SUM() and add MIN() and MAX() 

### DIFF
--- a/src/Queries/Mysql/AggregationTrait.php
+++ b/src/Queries/Mysql/AggregationTrait.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace SimpleCrud\Queries\Mysql;
+
+use PDO;
+
+/**
+ * Trait with common funcions used in aggregation queries (min,max,avg,count,sum).
+ *
+ * @property \SimpleCrud\Table $table
+ */
+trait AggregationTrait
+{
+    use ExtendedSelectionTrait;
+    protected $field;
+
+    /**
+     * Set the field name to sum over.
+     *
+     * @param string $field
+     *
+     * @return self
+     */
+    public function field($field)
+    {
+        $this->field = $field;
+
+        return $this;
+    }
+
+    /**
+     * Run the query and return the value.
+     * 
+     * @return int
+     */
+    public function run()
+    {
+        $result = $this->__invoke()->fetch();
+        $field = $this->table->{$this->field};
+        
+        return $field->dataFromDatabase($result[0]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __invoke()
+    {
+        $statement = $this->table->getDatabase()->execute((string) $this, $this->marks);
+        $statement->setFetchMode(PDO::FETCH_NUM);
+
+        return $statement;
+    }
+
+    /**
+     * Build and return the query.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $query = "SELECT ".self::AGGREGATION_FUNCTION."(`{$this->field}`) FROM `{$this->table->getName()}`";
+
+        $query .= $this->fromToString();
+        $query .= $this->whereToString();
+        $query .= $this->limitToString();
+
+        return $query;
+    }
+}

--- a/src/Queries/Mysql/Avg.php
+++ b/src/Queries/Mysql/Avg.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SimpleCrud\Queries\Mysql;
+
+use SimpleCrud\Queries\Query;
+use SimpleCrud\Table;
+
+
+/**
+ * Manages a database select avg query in Mysql databases.
+ */
+class Avg extends Query
+{
+    use AggregationTrait;
+    const AGGREGATION_FUNCTION = 'AVG';
+    
+    /**
+     * Run the query and return the value.
+     * 
+     * @return int
+     */
+    public function run()
+    {
+        $result = $this->__invoke()->fetch();
+        
+        return (float) $result[0];
+    }
+    
+}

--- a/src/Queries/Mysql/Count.php
+++ b/src/Queries/Mysql/Count.php
@@ -4,14 +4,14 @@ namespace SimpleCrud\Queries\Mysql;
 
 use SimpleCrud\Queries\Query;
 use SimpleCrud\Table;
-use PDO;
 
 /**
  * Manages a database select count query.
  */
 class Count extends Query
 {
-    use ExtendedSelectionTrait;
+    use AggregationTrait;
+    const AGGREGATION_FUNCTION = 'COUNT';
 
     /**
      * Returns the count.
@@ -27,23 +27,13 @@ class Count extends Query
         return (int) $result[0];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function __invoke()
-    {
-        $statement = $this->table->getDatabase()->execute((string) $this, $this->marks);
-        $statement->setFetchMode(PDO::FETCH_NUM);
-
-        return $statement;
-    }
 
     /**
      * {@inheritdoc}
      */
     public function __toString()
     {
-        $query = "SELECT COUNT(*) FROM `{$this->table->getName()}`";
+        $query = "SELECT ".self::AGGREGATION_FUNCTION."(*) FROM `{$this->table->getName()}`";
 
         $query .= $this->fromToString();
         $query .= $this->whereToString();

--- a/src/Queries/Mysql/Max.php
+++ b/src/Queries/Mysql/Max.php
@@ -7,16 +7,16 @@ use SimpleCrud\Table;
 use PDO;
 
 /**
- * Manages a database select sum query in Mysql databases.
+ * Manages a database select max query in Mysql databases.
  */
-class Sum extends Query
+class Max extends Query
 {
     use ExtendedSelectionTrait;
 
     protected $field;
 
     /**
-     * Set the field name to sum over.
+     * Set the field name to maximize over.
      *
      * @param string $field
      *
@@ -60,7 +60,7 @@ class Sum extends Query
      */
     public function __toString()
     {
-        $query = "SELECT SUM(`{$this->field}`) FROM `{$this->table->getName()}`";
+        $query = "SELECT MAX(`{$this->field}`) FROM `{$this->table->getName()}`";
 
         $query .= $this->fromToString();
         $query .= $this->whereToString();

--- a/src/Queries/Mysql/Max.php
+++ b/src/Queries/Mysql/Max.php
@@ -4,68 +4,13 @@ namespace SimpleCrud\Queries\Mysql;
 
 use SimpleCrud\Queries\Query;
 use SimpleCrud\Table;
-use PDO;
+
 
 /**
  * Manages a database select max query in Mysql databases.
  */
 class Max extends Query
 {
-    use ExtendedSelectionTrait;
-
-    protected $field;
-
-    /**
-     * Set the field name to maximize over.
-     *
-     * @param string $field
-     *
-     * @return self
-     */
-    public function field($field)
-    {
-        $this->field = $field;
-
-        return $this;
-    }
-
-    /**
-     * Run the query and return the value.
-     * 
-     * @return int
-     */
-    public function run()
-    {
-        $result = $this->__invoke()->fetch();
-        $field = $this->table->{$this->field};
-        
-        return $field->dataFromDatabase($result[0]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __invoke()
-    {
-        $statement = $this->table->getDatabase()->execute((string) $this, $this->marks);
-        $statement->setFetchMode(PDO::FETCH_NUM);
-
-        return $statement;
-    }
-
-    /**
-     * Build and return the query.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        $query = "SELECT MAX(`{$this->field}`) FROM `{$this->table->getName()}`";
-
-        $query .= $this->fromToString();
-        $query .= $this->whereToString();
-        $query .= $this->limitToString();
-
-        return $query;
-    }
+    use AggregationTrait;
+    const AGGREGATION_FUNCTION = 'MAX';
 }

--- a/src/Queries/Mysql/Min.php
+++ b/src/Queries/Mysql/Min.php
@@ -4,68 +4,13 @@ namespace SimpleCrud\Queries\Mysql;
 
 use SimpleCrud\Queries\Query;
 use SimpleCrud\Table;
-use PDO;
+
 
 /**
  * Manages a database select min query in Mysql databases.
  */
 class Min extends Query
 {
-    use ExtendedSelectionTrait;
-
-    protected $field;
-
-    /**
-     * Set the field name to maximize over.
-     *
-     * @param string $field
-     *
-     * @return self
-     */
-    public function field($field)
-    {
-        $this->field = $field;
-
-        return $this;
-    }
-
-    /**
-     * Run the query and return the value.
-     * 
-     * @return int
-     */
-    public function run()
-    {
-        $result = $this->__invoke()->fetch();
-        $field = $this->table->{$this->field};
-        
-        return $field->dataFromDatabase($result[0]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __invoke()
-    {
-        $statement = $this->table->getDatabase()->execute((string) $this, $this->marks);
-        $statement->setFetchMode(PDO::FETCH_NUM);
-
-        return $statement;
-    }
-
-    /**
-     * Build and return the query.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        $query = "SELECT MIN(`{$this->field}`) FROM `{$this->table->getName()}`";
-
-        $query .= $this->fromToString();
-        $query .= $this->whereToString();
-        $query .= $this->limitToString();
-
-        return $query;
-    }
+    use AggregationTrait;
+    const AGGREGATION_FUNCTION = 'MIN';
 }

--- a/src/Queries/Mysql/Min.php
+++ b/src/Queries/Mysql/Min.php
@@ -7,16 +7,16 @@ use SimpleCrud\Table;
 use PDO;
 
 /**
- * Manages a database select sum query in Mysql databases.
+ * Manages a database select min query in Mysql databases.
  */
-class Sum extends Query
+class Min extends Query
 {
     use ExtendedSelectionTrait;
 
     protected $field;
 
     /**
-     * Set the field name to sum over.
+     * Set the field name to maximize over.
      *
      * @param string $field
      *
@@ -60,7 +60,7 @@ class Sum extends Query
      */
     public function __toString()
     {
-        $query = "SELECT SUM(`{$this->field}`) FROM `{$this->table->getName()}`";
+        $query = "SELECT MIN(`{$this->field}`) FROM `{$this->table->getName()}`";
 
         $query .= $this->fromToString();
         $query .= $this->whereToString();

--- a/src/Queries/Mysql/Sum.php
+++ b/src/Queries/Mysql/Sum.php
@@ -4,68 +4,12 @@ namespace SimpleCrud\Queries\Mysql;
 
 use SimpleCrud\Queries\Query;
 use SimpleCrud\Table;
-use PDO;
 
 /**
  * Manages a database select sum query in Mysql databases.
  */
 class Sum extends Query
 {
-    use ExtendedSelectionTrait;
-
-    protected $field;
-
-    /**
-     * Set the field name to sum over.
-     *
-     * @param string $field
-     *
-     * @return self
-     */
-    public function field($field)
-    {
-        $this->field = $field;
-
-        return $this;
-    }
-
-    /**
-     * Run the query and return the value.
-     * 
-     * @return int
-     */
-    public function run()
-    {
-        $result = $this->__invoke()->fetch();
-        $field = $this->table->{$this->field};
-        
-        return $field->dataFromDatabase($result[0]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __invoke()
-    {
-        $statement = $this->table->getDatabase()->execute((string) $this, $this->marks);
-        $statement->setFetchMode(PDO::FETCH_NUM);
-
-        return $statement;
-    }
-
-    /**
-     * Build and return the query.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        $query = "SELECT SUM(`{$this->field}`) FROM `{$this->table->getName()}`";
-
-        $query .= $this->fromToString();
-        $query .= $this->whereToString();
-        $query .= $this->limitToString();
-
-        return $query;
-    }
+    use AggregationTrait;
+    const AGGREGATION_FUNCTION = 'SUM';
 }

--- a/src/Queries/Sqlite/Avg.php
+++ b/src/Queries/Sqlite/Avg.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SimpleCrud\Queries\Sqlite;
+
+use SimpleCrud\Queries\Mysql\Max as BaseAvg;
+
+/**
+ * Manages a database max query in Sqlite databases.
+ */
+class Avg extends BaseAvg
+{
+}

--- a/src/Queries/Sqlite/Max.php
+++ b/src/Queries/Sqlite/Max.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SimpleCrud\Queries\Sqlite;
+
+use SimpleCrud\Queries\Mysql\Max as BaseMax;
+
+/**
+ * Manages a database max query in Sqlite databases.
+ */
+class Max extends BaseMax
+{
+}

--- a/src/Queries/Sqlite/Min.php
+++ b/src/Queries/Sqlite/Min.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SimpleCrud\Queries\Sqlite;
+
+use SimpleCrud\Queries\Mysql\Min as BaseMin;
+
+/**
+ * Manages a database min query in Sqlite databases.
+ */
+class Min extends BaseMin
+{
+}


### PR DESCRIPTION
 - fix hardcoded typecast to (int) for SELECT SUM(field) ... queries.
   for example SUM(..) over float fields are now cast to the respective datatype
   of the field.

 - implement SELECT MIN(..) and SELECT MAX(..) queries